### PR TITLE
Create 11-fix-wifi-macs

### DIFF
--- a/etc/hotplug.d/ieee80211/11-fix-wifi-macs
+++ b/etc/hotplug.d/ieee80211/11-fix-wifi-macs
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+[ "$ACTION" == "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	gl-b3000)
+		label_mac=$(cat /sys/class/net/eth1/address)
+		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
+		;;
+esac


### PR DESCRIPTION
Assign macs to wifi0 & wifi1 to restore openwrt luci functionality.

problem
```
root@GL-B3000:/# cat /sys/class/net/wifi0/phy80211/macaddress                                                                                           
00:00:00:00:00:00                                                                                                                                       
root@GL-B3000:/# cat /sys/class/net/wifi1/phy80211/macaddress                                                                                           
00:00:00:00:00:00  
```
```
root@GL-B3000:/# iwinfo                                                                                                                                 
wifi0     ESSID: unknown                                                                                                                                
          Access Point: 00:00:00:00:00:00                                                                                                               
          Mode: Unknown Channel: 6 (2.437 GHz) HT Mode: HT20                                                                                            
          Tx-Power: unknown  Link Quality: unknown/unknown                                                                                              
          Signal: unknown  Noise: unknown                                                                                                               
          Bit Rate: unknown                                                                                                                             
          Encryption: unknown                                                                                                                           
          Type: qcawifi  HW Mode(s): 802.11abgnax                                                                                                       
          Hardware: unknown [Generic Atheros]                                                                                                           
          TX power offset: unknown                                                                                                                      
          Frequency offset: unknown                                                                                                                     
          Supports VAPs: yes  PHY name: phy2                                                                                                            
                                                                                                                                                        
wifi1     ESSID: unknown                                                                                                                                
          Access Point: 00:00:00:00:00:00                                                                                                               
          Mode: Unknown Channel: 48 (5.240 GHz) HT Mode: HT20                                                                                           
          Tx-Power: unknown  Link Quality: unknown/unknown                                                                                              
          Signal: unknown  Noise: unknown                                                                                                               
          Bit Rate: unknown                                                                                                                             
          Encryption: unknown                                                                                                                           
          Type: qcawifi  HW Mode(s): 802.11anacax                                                                                                       
          Hardware: unknown [Generic Atheros]                                                                                                           
          TX power offset: unknown                                                                                                                      
          Frequency offset: unknown                                                                                                                     
          Supports VAPs: yes  PHY name: phy3                                                                                                            
     ...
```